### PR TITLE
Add PodDisruptionBudget resource to ClusterRoles

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Any admin on GitLab is an admin of the Kubernetes cluster.
 | networkpolicies               | R     | R        | R+W       | R+W        |
 | persistentvolumeclaims        | R     | R        | R+W       | R+W        |
 | persistentvolumeclaims/status | R     | R        | R+W       | R+W        |
+| poddisruptionbudgets          | R     | R        | R+W       | R+W        |
+| poddisruptionbudgets/status   | R     | R        | R+W       | R+W        |
 | serviceaccounts               | R     | R        | R+W       | R+W        |
 | certificates                  |       |          | R+W       | R+W        |
 | secrets                       |       |          | R+W       | R+W        |

--- a/deploy/configuration.yaml
+++ b/deploy/configuration.yaml
@@ -49,6 +49,8 @@ rules:
   - networkpolicies
   - persistentvolumeclaims
   - persistentvolumeclaims/status
+  - poddisruptionbudgets
+  - poddisruptionbudgets/status
   - serviceaccounts
   verbs:
   - get
@@ -96,6 +98,8 @@ rules:
   - networkpolicies
   - persistentvolumeclaims
   - persistentvolumeclaims/status
+  - poddisruptionbudgets
+  - poddisruptionbudgets/status
   - serviceaccounts
   verbs:
   - get
@@ -141,6 +145,8 @@ rules:
   - networkpolicies
   - persistentvolumeclaims
   - persistentvolumeclaims/status
+  - poddisruptionbudgets
+  - poddisruptionbudgets/status
   - secrets
   - serviceaccounts
   verbs:
@@ -206,6 +212,8 @@ rules:
   - networkpolicies
   - persistentvolumeclaims
   - persistentvolumeclaims/status
+  - poddisruptionbudgets
+  - poddisruptionbudgets/status
   - resourcequotas
   - rolebindings
   - roles


### PR DESCRIPTION
Adding PodDisruptionBudget resource to default ClusterRoles.

Signed-off-by: Laurent Marchaud <laurent@marchaud.com>