### PR TITLE
fix a bug with the creation of new rolebinding with recent kubernetes library

### DIFF
--- a/gitlab2rbac.py
+++ b/gitlab2rbac.py
@@ -441,7 +441,7 @@ class KubernetesHelper(object):
                     namespace=namespace, name=name, labels=labels
                 ),
                 subjects=[
-                    kubernetes.client.V1Subject(
+                    kubernetes.client.RbacV1Subject(
                         name=user,
                         kind="User",
                         api_group="rbac.authorization.k8s.io",


### PR DESCRIPTION
`2024-08-23 08:21:49,291 - ERROR - unable to create user role binding :: module 'kubernetes.client' has no attribute 'V1Subject'`