### PR TITLE
Add support for the new Gitlab role "Planner"

### DIFF
--- a/gitlab2rbac.py
+++ b/gitlab2rbac.py
@@ -23,6 +23,7 @@ logging.getLogger("gql").setLevel(logging.WARNING)
 class GitlabHelper:
     ACCESS_LEVEL_REFERENCE: dict[int, str] = {
         10: "guest",
+        15: "planner",
         20: "reporter",
         30: "developer",
         40: "maintainer",


### PR DESCRIPTION
Required for Gitlab 17.7+. Backward compatible for other versions.